### PR TITLE
silence 25.1 byte-compiler

### DIFF
--- a/imenu-anywhere.el
+++ b/imenu-anywhere.el
@@ -177,7 +177,8 @@ See the code for `imenu-anywhere--preprocess-entry-ido' and
                 (featurep 'ido )
                 imenu-anywhere-use-ido)
       ;; ido initialization
-      (ido-init-completion-maps)
+      (with-no-warnings
+        (ido-init-completion-maps))
       (add-hook 'minibuffer-setup-hook 'ido-minibuffer-setup)
       (add-hook 'choose-completion-string-functions 'ido-choose-completion-string)
       (setq reset-ido t))


### PR DESCRIPTION
`ido-init-completion-maps` is obsolete as of 25.1.  But for backward
compatibility reasons it is still required.  Wrap in `with-no-warnings`
to silence the 25.1 byte-compiler.