### PR TITLE
Load helm-build-sync-source from helm-core.

### DIFF
--- a/imenu-anywhere.el
+++ b/imenu-anywhere.el
@@ -202,7 +202,7 @@ list of one entry otherwise."
 (defvar helm-sources-using-default-as-input)
 (autoload 'helm "helm")
 (autoload 'helm-highlight-current-line "helm-utils")
-(autoload 'helm-build-sync-source "helm-source")
+(autoload 'helm-build-sync-source "helm-core")
 (autoload 'with-helm-current-buffer "helm-lib")
 
 (eval-after-load "helm"


### PR DESCRIPTION
The compilation system comes in the helm-core package:
https://github.com/emacs-helm/helm#install-and-use-only-helm-core-package