### PR TITLE
Update check for imenu integration

### DIFF
--- a/imenu-anywhere.el
+++ b/imenu-anywhere.el
@@ -99,7 +99,7 @@ the major modes of interest."
   "Return an alist of candidates in the current buffer."
   ;; avoid imenu throwing ugly messages
   (when (or (and imenu-prev-index-position-function
-                 imenu-generic-expression)
+                 imenu-extract-index-name-function)
             (not (eq imenu-create-index-function 'imenu-default-create-index-function)))
     ;; (ignore-errors
     (setq imenu--index-alist nil)


### PR DESCRIPTION
imenu.el recommends the following as one of two main ways for creating an index: Move point to the end of the buffer, then repeatedly call `'imenu-prev-index-position-function` and `'imenu-extract-index-name-function`.

This is how erlang.el integrates with imenu. However, erlang.el does not define imenu-generic-expression, so when I tried to use imenu-anywhere with .erl files, I got a "No imenu tags" error, even though the `imenu` command behaved fine.

This PR updates the test in `imenu-anywhere-buffer-candidates` to check for the presence of `imenu-extract-index-name-function` instead of `imenu-generic-expression`. Changing this allows erlang-mode to work properly with imenu and imenu-anywhere. I haven't tested it extensively outside of use with erlang-mode, but I don't suspect that it will break any other major modes.
